### PR TITLE
Fix: Use consistent local date for prices and invoices

### DIFF
--- a/screens/CreateInvoiceScreen.js
+++ b/screens/CreateInvoiceScreen.js
@@ -7,6 +7,7 @@ import { getPricesByDate, saveInvoice, getSetting } from '../db';
 import { generateInvoicePdf } from '../utils/pdfGenerator';
 import { shareAsync } from 'expo-sharing';
 import InvoiceItemForm from './components/InvoiceItemForm';
+import { getTodayDate } from '../utils/date';
 
 const CreateInvoiceScreen = ({ navigation }) => {
   // State for the overall invoice
@@ -21,7 +22,7 @@ const CreateInvoiceScreen = ({ navigation }) => {
   // Fetch initial data
   useEffect(() => {
     const loadData = async () => {
-      const today = new Date().toISOString().slice(0, 10);
+      const today = getTodayDate();
       try {
         const rates = await getPricesByDate(today);
         if (!rates) {
@@ -53,7 +54,7 @@ const CreateInvoiceScreen = ({ navigation }) => {
     const finalPayable = invoiceItems.reduce((acc, item) => acc + item.finalTotal, 0);
     const invoiceData = {
       customerName: customerName, mobile: mobile,
-      date: new Date().toISOString().slice(0, 10), totalAmount: finalPayable,
+      date: getTodayDate(), totalAmount: finalPayable,
     };
     try {
       const invoiceId = await saveInvoice(invoiceData, invoiceItems);

--- a/screens/PriceEntryScreen.js
+++ b/screens/PriceEntryScreen.js
@@ -3,20 +3,13 @@ import { View, StyleSheet, Alert } from 'react-native';
 import { TextInput, Button, Text, Card, Divider } from 'react-native-paper';
 import { Picker } from '@react-native-picker/picker';
 import { getPricesByDate, savePrices } from '../db';
+import { getTodayDate } from '../utils/date';
 
 const PriceEntryScreen = ({ navigation }) => {
   const [gold24k, setGold24k] = useState('');
   const [silver, setSilver] = useState('');
   const [selectedKarat, setSelectedKarat] = useState('24K');
   const [calculatedPrice, setCalculatedPrice] = useState('');
-
-  const getTodayDate = () => {
-    const today = new Date();
-    const yyyy = today.getFullYear();
-    const mm = String(today.getMonth() + 1).padStart(2, '0');
-    const dd = String(today.getDate()).padStart(2, '0');
-    return `${yyyy}-${mm}-${dd}`;
-  };
 
   useEffect(() => {
     const loadPrices = async () => {

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,0 +1,7 @@
+export const getTodayDate = () => {
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = String(today.getMonth() + 1).padStart(2, '0');
+  const dd = String(today.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};


### PR DESCRIPTION
The application was using two different methods for generating the current date, causing a bug where prices saved in one timezone would not be found by the invoice screen.

- `PriceEntryScreen` used a custom function that returned the local date.
- `CreateInvoiceScreen` used `Date.toISOString()`, which returned the UTC date.

This commit fixes the issue by creating a shared utility function, `getTodayDate`, which returns the local date in `YYYY-MM-DD` format. Both screens have been updated to use this consistent function, ensuring that prices are saved and retrieved using the same local date.